### PR TITLE
Update `cadvisor` and `opentelemetry-collector` images to support arm64 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This setup uses Loki for logs, Prometheus for metrics, and Jaeger for tracing. It will automatically collect logs from other Docker containers running on the same server if the installation steps below are followed.
 
-The Livingdocs server can be configured to send metrics data to the stack, and there is also a way to send log data when running the service without the use of Docker (for local development purposes). More details can be found in the [Livingdocs documentation](https://docs.livingdocs.io/).
+The Livingdocs Server can be configured to send metrics data to the stack, and there is also a way to send log data when running the service without the use of Docker (for local development purposes). More details can be found in the [Livingdocs Server telemetry documentation](https://docs.livingdocs.io/operations/telemetry/#setup).
 
 The stack includes the following:
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ networks:
 
 services:
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.43.0
+    image: gcr.io/cadvisor/cadvisor:v0.45.0
     restart: unless-stopped
     command: --docker_only=true --store_container_labels=false
     ports: ["9081:8080"]
@@ -57,7 +57,7 @@ services:
     user: "1000:1000"
 
   opentelemetry-collector:
-    image: otel/opentelemetry-collector:0.18.0
+    image: otel/opentelemetry-collector:0.58.0
     restart: unless-stopped
     command: --config=/conf/otel-collector.config.yaml
     ports: ["9464:9464", "55680:55680", "55681:55681"]

--- a/otel-collector.yaml
+++ b/otel-collector.yaml
@@ -9,11 +9,10 @@ exporters:
 
 processors:
   batch:
-  queued_retry:
 
 service:
   pipelines:
     metrics:
       receivers: [otlp]
       exporters: [prometheus]
-      processors: [batch, queued_retry]
+      processors: [batch]


### PR DESCRIPTION
chore: Update `cadvisor` and `opentelemetry-collector` images to support arm64 architecture.
docs: Add the link to telemetry instead of generic documentation since it is more clear what you are expected to do to get Jaeger metrics.